### PR TITLE
Fix POM license issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # The LinkedIn Fairness Toolkit (LiFT)
 [![Build Status](https://travis-ci.com/linkedin/LiFT.svg?branch=main)](https://travis-ci.com/linkedin/LiFT)
+[![Download](https://api.bintray.com/packages/linkedin/maven/LiFT/images/download.svg)](https://bintray.com/linkedin/maven/LiFT/_latestVersion)
 [![License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)](LICENSE)
 
 The LinkedIn Fairness Toolkit (LiFT) is a Scala/Spark library that enables the measurement of fairness in large scale machine learning workflows.
@@ -77,14 +78,19 @@ Tests typically run with the `test` task. If you want to force-run all tests, yo
 ```
 
 
-### Using the JAR File
+### Add a LiFT dependency to your project
+
+Please check [Bintray](https://bintray.com/beta/#/linkedin/maven/LiFT) for the latest artifact versions.
+
+#### Using the JAR File
 
 Depending on the mode of usage, the built JAR can be deployed as part of an offline data pipeline, depended 
 upon to build jobs using its APIs, or added to the classpath of a Spark Jupyter notebook or a Spark Shell instance. For
 example:
 ```bash
-$SPARK_HOME/bin/spark-shell --jars target/lift_2.11.jar
+$SPARK_HOME/bin/spark-shell --jars target/lift_2.3.0_2.11_0.1.3.jar
 ```
+
 
 ### Usage Examples
 

--- a/gradle/shipkit.gradle
+++ b/gradle/shipkit.gradle
@@ -4,6 +4,7 @@ shipkit {
     gitHub.readOnlyAuthToken = "cccb537c0a5ddeb4bfdb2dfa307180e2b42a40ec"
     gitHub.writeAuthToken = System.getenv("GH_WRITE_TOKEN")
     git.releasableBranchRegex = "main|release/.+"
+    team.developers = ['sriramvasudevan:Sriram Vasudevan']
 }
 
 allprojects {
@@ -20,6 +21,22 @@ allprojects {
                 name = 'LiFT'
                 licenses = ['BSD 2-CLAUSE']
                 labels = ['spark', 'fairness', 'machine learning']
+                description = 'A Scala/Spark library that enables the measurement of fairness in large scale machine learning workflows.'
+            }
+        }
+    }
+
+    plugins.withId("org.shipkit.java-publish") {
+        publishing.publications.javaLibrary.pom.withXml {
+            //refer to Groovy xml Node reference for more info how to manipulate xml
+            asNode().licenses.replaceNode {
+                licenses {
+                    license {
+                        name "BSD 2-CLAUSE"
+                        url "https://github.com/linkedin/LiFT/blob/main/LICENSE"
+                        distribution "repo"
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
The POM license mentions the MIT license, despite linking to LiFT's BSD
2-Clause. The resolution is documented in mockito/shipkit#755.

Also updated the Readme to add the Bintray artifact download badge,
and to indicate the correct jar name.