### PR TITLE
Update Readme to document JCenter details

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,41 @@ Tests typically run with the `test` task. If you want to force-run all tests, yo
 
 Please check [Bintray](https://bintray.com/beta/#/linkedin/maven/LiFT) for the latest artifact versions.
 
+#### Gradle example
+
+The artifacts are available in JCenter, so you can specify the JCenter repository in the top-level build.gradle file.
+
+```
+repositories {
+    jcenter()
+}
+```
+
+Add the LiFT dependency to the module-level `build.gradle` file. Here are some examples for multiple recent Spark/Scala version combinations:
+
+```
+dependencies {
+    compile 'com.linkedin.lift:lift_2.3.0_2.11:0.1.4'
+}
+```
+```
+dependencies {
+    compile 'com.linkedin.lift:lift_2.4.3_2.11:0.1.4'
+}
+```
+```
+dependencies {
+    compile 'com.linkedin.lift:lift_2.4.3_2.12:0.1.4'
+}
+```
+
 #### Using the JAR File
 
 Depending on the mode of usage, the built JAR can be deployed as part of an offline data pipeline, depended 
 upon to build jobs using its APIs, or added to the classpath of a Spark Jupyter notebook or a Spark Shell instance. For
 example:
 ```bash
-$SPARK_HOME/bin/spark-shell --jars target/lift_2.3.0_2.11_0.1.3.jar
+$SPARK_HOME/bin/spark-shell --jars target/lift_2.3.0_2.11_0.1.4.jar
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -78,11 +78,11 @@ Tests typically run with the `test` task. If you want to force-run all tests, yo
 ```
 
 
-### Add a LiFT dependency to your project
+### Add a LiFT Dependency to Your Project
 
 Please check [Bintray](https://bintray.com/beta/#/linkedin/maven/LiFT) for the latest artifact versions.
 
-#### Gradle example
+#### Gradle Example
 
 The artifacts are available in JCenter, so you can specify the JCenter repository in the top-level build.gradle file.
 


### PR DESCRIPTION
This PR adds details about how to add the LiFT dependency to projects that use the Gradle build system. We're also taking this opportunity to release a new patch version of LiFT: 0.1.4.