### PR TITLE
Update computeJoinedDF to take a DataFrame

### DIFF
--- a/lift/src/main/scala/com/linkedin/lift/eval/jobs/MeasureDatasetFairnessMetrics.scala
+++ b/lift/src/main/scala/com/linkedin/lift/eval/jobs/MeasureDatasetFairnessMetrics.scala
@@ -22,16 +22,16 @@ object MeasureDatasetFairnessMetrics {
       .getOrCreate()
 
     val args = MeasureDatasetFairnessMetricsCmdLineArgs.parseArgs(progArgs)
-    val dfReader = spark.read.format(args.dataFormat).options(args.dataOptions)
 
     // One could choose to do their own preprocessing here
     // For example, filtering out only certain records based on some threshold
-    val df = dfReader
-      .load(args.datasetPath)
+    val dfReader = spark.read.format(args.dataFormat).options(args.dataOptions)
+    val df = dfReader.load(args.datasetPath)
       .select(args.uidField, args.labelField)
+    val protectedDF = dfReader.load(args.protectedDatasetPath)
 
     // Similar preprocessing can be done with the protected attribute data
-    val joinedDF = FairnessMetricsUtils.computeJoinedDF(dfReader, df, args.uidField,
+    val joinedDF = FairnessMetricsUtils.computeJoinedDF(protectedDF, df, args.uidField,
       args.protectedDatasetPath, args.uidProtectedAttributeField,
       args.protectedAttributeField)
 

--- a/lift/src/main/scala/com/linkedin/lift/eval/jobs/MeasureModelFairnessMetrics.scala
+++ b/lift/src/main/scala/com/linkedin/lift/eval/jobs/MeasureModelFairnessMetrics.scala
@@ -22,15 +22,16 @@ object MeasureModelFairnessMetrics {
       .getOrCreate()
 
     val args = MeasureModelFairnessMetricsCmdLineArgs.parseArgs(progArgs)
-    val dfReader = spark.read.format(args.dataFormat).options(args.dataOptions)
 
     // One could choose to do their own preprocessing here
     // For example, filtering out only certain records based on some threshold
+    val dfReader = spark.read.format(args.dataFormat).options(args.dataOptions)
     val df = FairnessMetricsUtils.projectIdLabelsAndScores(dfReader.load(args.datasetPath),
       args.uidField, args.labelField, args.scoreField, args.groupIdField)
+    val protectedDF = dfReader.load(args.protectedDatasetPath)
 
     // Similar preprocessing can be done with the protected attribute data
-    val joinedDF = FairnessMetricsUtils.computeJoinedDF(dfReader, df, args.uidField,
+    val joinedDF = FairnessMetricsUtils.computeJoinedDF(protectedDF, df, args.uidField,
       args.protectedDatasetPath, args.uidProtectedAttributeField,
       args.protectedAttributeField)
     joinedDF.persist

--- a/lift/src/main/scala/com/linkedin/lift/types/Distribution.scala
+++ b/lift/src/main/scala/com/linkedin/lift/types/Distribution.scala
@@ -76,7 +76,7 @@ case class Distribution(
       }
       .groupBy(_._1)
       .map { case (marginalDimensions, countsGroup) =>
-        (marginalDimensions, countsGroup.map{_._2}.sum)}
+        (marginalDimensions, countsGroup.map(_._2).sum)}
 
     Distribution(entries = marginalDistributionEntries)
   }

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 #Version of the produced binaries. This file is intended to be checked-in.
 #It will be automatically bumped by release automation.
-version=0.1.5
+version=0.2.0
 previousVersion=0.1.4


### PR DESCRIPTION
* The `computeJoinedDF` method accepts a` DataFrameReader` to load the protected attribute `DataFrame`. However, this means that the data must necessarily be read / loaded in, and that a `DataFrameReader` must be used to achieve this. The API is updated now to accept a `DataFrame` instead.
* The version is bumped to 0.2.0 due to the API change.
* Fixed a unit test for computeModelMetrics that was testing `computeDatasetMetrics` instead.
* Fixed some code style issues.